### PR TITLE
Ext bitmap source refactor

### DIFF
--- a/LeerCopyWPF/LeerCopyWPF.csproj
+++ b/LeerCopyWPF/LeerCopyWPF.csproj
@@ -81,7 +81,7 @@
     </Compile>
     <Compile Include="Controllers\SelectControl.cs" />
     <Compile Include="Enums\Actions.cs" />
-    <Compile Include="Models\ExtBitmapSource.cs" />
+    <Compile Include="Models\SimpleScreen.cs" />
     <Compile Include="Settings.cs" />
     <Compile Include="Utilities\ActionConverter.cs" />
     <Compile Include="Utilities\BitmapUtilities.cs" />

--- a/LeerCopyWPF/Models/SimpleScreen.cs
+++ b/LeerCopyWPF/Models/SimpleScreen.cs
@@ -7,32 +7,38 @@ using System.Windows.Media.Imaging;
 namespace LeerCopyWPF.Models
 {
     /// <summary>
-    /// Extends functionality of BitmapSource data structure to include
-    /// extra metadata from structures such as the Screen class
+    /// 'Wrapper' class for System.Windows.Forms.Screen to hold relevant
+    /// screen data for screen capturing
     /// </summary>
-    public class ExtBitmapSource : IEquatable<ExtBitmapSource>, IComparable<ExtBitmapSource>
+    public class SimpleScreen : IEquatable<SimpleScreen>, IComparable<SimpleScreen>
     {
         /// <summary>
-        /// Bitmap source object
+        /// The number of bits of memory, associated with one pixel of data
         /// </summary>
-        public BitmapSource Bitmap { get; set; }
+        public int BitsPerPixel { get; set; }
         /// <summary>
         /// Bounds of the Bitmap relative to screen captured on
         /// </summary>
         public Rect Bounds { get; set; }
+        /// <summary>
+        /// Name of the device associated with screen
+        /// </summary>
+        public string DeviceName { get; set; }
 
 
-        public ExtBitmapSource()
+        public SimpleScreen()
         {
-            Bitmap = null;
+            BitsPerPixel = -1;
             Bounds = new Rect();
+            DeviceName = "<none>";
         }
 
 
-        public ExtBitmapSource(BitmapSource bms, Rect rect)
+        public SimpleScreen(int bpp, Rect bounds, string name)
         {
-            Bitmap = bms;
-            Bounds = rect;
+            BitsPerPixel = bpp;
+            Bounds = bounds;
+            DeviceName = name;
         }
 
 
@@ -48,13 +54,13 @@ namespace LeerCopyWPF.Models
                 return false;
             }
 
-            if (!(obj is ExtBitmapSource ebs))
+            if (!(obj is SimpleScreen ss))
             {
                 return false;
             }
 
-            return this.Equals(obj as ExtBitmapSource);
-        }
+            return this.Equals(obj as SimpleScreen);
+        } // Equals
 
 
         /// <summary>
@@ -62,25 +68,29 @@ namespace LeerCopyWPF.Models
         /// </summary>
         /// <param name="other"></param>
         /// <returns>True if equal, false otherwise</returns>
-        public bool Equals(ExtBitmapSource other)
+        public bool Equals(SimpleScreen other)
         {
             if (other == null)
             {
                 return false;
             }
 
-            return (Bounds.Equals(other.Bounds)) && (Bitmap == other.Bitmap);
-        }
-
-
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
+            return (Bounds.Equals(other.Bounds)) && (DeviceName.Equals(other.DeviceName));
+        } // Equals
 
 
         /// <summary>
-        /// Compares this ExtBitmapSource object with other. Top, left is least while bottom, right is greatest value.
+        /// Calculates object's hash code
+        /// </summary>
+        /// <returns></returns>
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        } // GetHashCode
+
+
+        /// <summary>
+        /// Compares this SimpleScreen object with other. Top, left is least while bottom, right is greatest value.
         /// Vertical positioning has greater priority than horizontal positioning.
         /// -1 -1 -1
         /// -1  x  1
@@ -92,7 +102,7 @@ namespace LeerCopyWPF.Models
         /// 0 if this object occurs in the same position in the sort order as other,
         /// or greater than 0 if this object follows other in sort order
         /// </returns>
-        public int CompareTo(ExtBitmapSource other)
+        public int CompareTo(SimpleScreen other)
         {
             Rect oBounds = other.Bounds;
 
@@ -152,6 +162,6 @@ namespace LeerCopyWPF.Models
                     }
                 }
             }
-        }
+        } // CompareTo
     }
 }

--- a/LeerCopyWPF/Utilities/BitmapUtilities.cs
+++ b/LeerCopyWPF/Utilities/BitmapUtilities.cs
@@ -148,14 +148,14 @@ namespace LeerCopyWPF.Utilities
         /// <summary>
         /// Captures the screen as a bitmap
         /// </summary>
-        /// <returns>Screen bitmap converted to BitmapSource object</returns>
-        public static ExtBitmapSource CaptureScreen(Screen screen)
+        /// <returns>Screen Bitmap converted to BitmapSource object</returns>
+        public static BitmapSource CaptureScreen(SimpleScreen screen)
         {
             BitmapSource bmSrc;
-            int screenLeft = screen.Bounds.Left;
-            int screenTop = screen.Bounds.Top;
-            int screenWidth = screen.Bounds.Width;
-            int screenHeight = screen.Bounds.Height;
+            int screenLeft = (int)screen.Bounds.Left;
+            int screenTop = (int)screen.Bounds.Top;
+            int screenWidth = (int)screen.Bounds.Width;
+            int screenHeight = (int)screen.Bounds.Height;
 
             using (Bitmap bitmap = new Bitmap(screenWidth, screenHeight, System.Drawing.Imaging.PixelFormat.Format32bppArgb))
             {
@@ -171,26 +171,29 @@ namespace LeerCopyWPF.Utilities
                 throw new ApplicationException("BitmapUtilities.CaptureScreen: Unable to convert \'Bitmap\' to \'BitmapSouce\' for screen " + screen.DeviceName);
             }
 
-            Rect scrBounds = new Rect(screenLeft, screenTop, screenWidth, screenHeight);
-            return new ExtBitmapSource(bmSrc, scrBounds);
+            return bmSrc;
         } // CaptureScreen
 
 
         /// <summary>
-        /// Returns sorted list all screens as bitmaps
+        /// Returns sorted list all screens
         /// </summary>
-        /// <returns>List of BitmapSource objects representing each screen</returns>
-        public static List<ExtBitmapSource> CaptureScreens()
+        /// <returns>List of SimpleScreen objects representing each screen</returns>
+        public static List<SimpleScreen> CaptureScreens()
         {
-            List<ExtBitmapSource> captureList = new List<ExtBitmapSource>();
+            SimpleScreen tmpScr;
+            Rect tmpBounds;
+            List<SimpleScreen> screenList = new List<SimpleScreen>();
 
             foreach (Screen screen in Screen.AllScreens)
             {
-                captureList.Add(CaptureScreen(screen));
+                tmpBounds = new Rect(screen.Bounds.Left, screen.Bounds.Top, screen.Bounds.Width, screen.Bounds.Height);
+                tmpScr = new SimpleScreen(screen.BitsPerPixel, tmpBounds, screen.DeviceName);
+                screenList.Add(tmpScr);
             }
 
-            captureList.Sort();
-            return captureList;
+            screenList.Sort();
+            return screenList;
         } // CaptureScreens
 
 

--- a/LeerCopyWPF/Views/MainWindow.xaml.cs
+++ b/LeerCopyWPF/Views/MainWindow.xaml.cs
@@ -22,7 +22,7 @@ namespace LeerCopyWPF.Views
         /// <summary>
         /// All screens in user's environment
         /// </summary>
-        private List<ExtBitmapSource> screens;
+        private List<SimpleScreen> screens;
         /// <summary>
         /// Currently displayed screen for capture
         /// </summary>


### PR DESCRIPTION
## Major Changes
+ Rename of ExtBitmapSource to SimpleScreen
+ SimpleScreen no longer keeps track of Bitmap of screen because it is not necessary
+ BitmapUtilities functions changed based on refactoring

## Minor Changes
+ MainWindow 'screens' list of SimpleScreens was renamed